### PR TITLE
Support for non-unique mobile phones

### DIFF
--- a/src/BrockAllen.MembershipReboot.Test/AccountService/UserAccountServiceTests.cs
+++ b/src/BrockAllen.MembershipReboot.Test/AccountService/UserAccountServiceTests.cs
@@ -2745,7 +2745,23 @@ namespace BrockAllen.MembershipReboot.Test.AccountService
         }
 
 
+        [TestMethod]
+        public void SetConfirmedMobilePhone_PhoneAlreadyInUse_PhoneIsNotUnique_Succeeds()
+        {
+            configuration.MobilePhoneIsUnique = false;
 
+            var acct1 = subject.CreateAccount("test1", "pass", "test1@test.com");
+            subject.SetConfirmedMobilePhone(acct1.ID, "123");
+            var acct2 = subject.CreateAccount("test2", "pass", "test2@test.com");
+            try
+            {
+                subject.SetConfirmedMobilePhone(acct2.ID, "123");
+            }
+            catch (ValidationException ex)
+            {
+                Assert.Fail("Different accounts should be allowed to have the same phone number.");
+            }
+        }
 
     }
 }

--- a/src/BrockAllen.MembershipReboot.Test/Configuration/SecuritySettingsTests.cs
+++ b/src/BrockAllen.MembershipReboot.Test/Configuration/SecuritySettingsTests.cs
@@ -29,6 +29,7 @@ namespace BrockAllen.MembershipReboot.Test.Accounts
             Assert.AreEqual(0, settings.PasswordResetFrequency);
             Assert.AreEqual(TimeSpan.FromMinutes(20), settings.VerificationKeyLifetime);
             Assert.AreEqual(true, settings.CertificateIsUnique);
+            Assert.AreEqual(true, settings.MobilePhoneIsUnique);
         }
     }
 }

--- a/src/BrockAllen.MembershipReboot/AccountService/UserAccountService.cs
+++ b/src/BrockAllen.MembershipReboot/AccountService/UserAccountService.cs
@@ -422,10 +422,13 @@ namespace BrockAllen.MembershipReboot
 
             if (String.IsNullOrWhiteSpace(phone)) return false;
 
-            var acct2 = this.userRepository.GetByMobilePhone(account.Tenant, phone);
-            if (acct2 != null)
+            if (this.Configuration.MobilePhoneIsUnique)
             {
-                return account.ID != acct2.ID;
+                var acct2 = this.userRepository.GetByMobilePhone(account.Tenant, phone);
+                if (acct2 != null)
+                {
+                    return account.ID != acct2.ID;
+                }
             }
             return false;
         }

--- a/src/BrockAllen.MembershipReboot/Configuration/MembershipRebootConfiguration.cs
+++ b/src/BrockAllen.MembershipReboot/Configuration/MembershipRebootConfiguration.cs
@@ -33,6 +33,7 @@ namespace BrockAllen.MembershipReboot
             this.PasswordResetFrequency = securitySettings.PasswordResetFrequency;
             this.VerificationKeyLifetime = securitySettings.VerificationKeyLifetime;
             this.CertificateIsUnique = securitySettings.CertificateIsUnique;
+            this.MobilePhoneIsUnique = securitySettings.MobilePhoneIsUnique;
 
             this.Crypto = new DefaultCrypto();
         }
@@ -51,6 +52,8 @@ namespace BrockAllen.MembershipReboot
         public int PasswordResetFrequency { get; set; }
         public TimeSpan VerificationKeyLifetime { get; set; }
         public bool CertificateIsUnique { get; set; }
+        public bool MobilePhoneIsUnique { get; set; }
+
 
         internal void Validate()
         {

--- a/src/BrockAllen.MembershipReboot/Configuration/SecuritySettings.cs
+++ b/src/BrockAllen.MembershipReboot/Configuration/SecuritySettings.cs
@@ -54,6 +54,7 @@ namespace BrockAllen.MembershipReboot
         private const string PASSWORDRESETFREQUENCY = "passwordResetFrequency";
         private const string VERIFICATIONKEYLIFETIME = "verificationKeyLifetime";
         private const string CERTIFICATEISUNIQUE = "certificateIsUnique";
+        private const string MOBILEPHONEISUNIQUE = "mobilePhoneIsUnique";
 
         [ConfigurationProperty(MULTITENANT, DefaultValue = MembershipRebootConstants.SecuritySettingDefaults.MultiTenant)]
         public bool MultiTenant
@@ -153,5 +154,11 @@ namespace BrockAllen.MembershipReboot
             set { this[CERTIFICATEISUNIQUE] = value; }
         }
 
+        [ConfigurationProperty(MOBILEPHONEISUNIQUE, DefaultValue = MembershipRebootConstants.SecuritySettingDefaults.MobilePhoneIsUnique)]
+        public bool MobilePhoneIsUnique
+        {
+            get { return (bool) this[MOBILEPHONEISUNIQUE]; }
+            set { this[MOBILEPHONEISUNIQUE] = value; }
+        }
     }
 }

--- a/src/BrockAllen.MembershipReboot/Constants/MembershipRebootConstants.cs
+++ b/src/BrockAllen.MembershipReboot/Constants/MembershipRebootConstants.cs
@@ -31,6 +31,7 @@ namespace BrockAllen.MembershipReboot
             internal const int PasswordResetFrequency = 0;
             internal const string VerificationKeyLifetime = "00:20:00";
             internal const bool CertificateIsUnique = true;
+            internal const bool MobilePhoneIsUnique = true;
         }
 
         public class UserAccount


### PR DESCRIPTION
Support for allowing non-unique mobile phones in user accounts through configuration property MobilePhoneIsUnique, which is true by default (this is original behavior) as discussed in #657.
